### PR TITLE
Update project to require go1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: 1.19
+          go-version: 1.26
 
       - name: Build
         run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module mkm.pub/byter
 
-go 1.19
+go 1.26
 
 require (
 	github.com/alecthomas/kong v0.9.0


### PR DESCRIPTION
Bumps the minimum Go version from 1.19 to 1.26 in go.mod and updates
the GitHub Actions CI workflow to build/test with go1.26.

https://claude.ai/code/session_0154UMydjFhAx1tQ31H7rmP5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the minimum Go version to 1.26 in go.mod and CI, so builds and tests run on Go 1.26 and newer. This enables use of Go 1.26 language and stdlib features.

- **Migration**
  - Update your local Go toolchain to 1.26+ before building or running tests.

<sup>Written for commit 7d4005ce95371ef1baf9ce55d8fd1e8e0d481a21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

