### PR TITLE
modernize Go idioms per go.dev/blog/gofix

### DIFF
--- a/get.go
+++ b/get.go
@@ -19,8 +19,8 @@ type GetCmd struct {
 	Common
 }
 
-func newClient(ctx context.Context, remote string) (*bytestream.Client, error) {
-	conn, err := grpc.DialContext(ctx, remote, grpc.WithTransportCredentials(insecure.NewCredentials()))
+func newClient(remote string) (*bytestream.Client, error) {
+	conn, err := grpc.NewClient(remote, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +29,7 @@ func newClient(ctx context.Context, remote string) (*bytestream.Client, error) {
 
 func (cmd *GetCmd) Run(cli *Context) error {
 	ctx := context.Background()
-	client, err := newClient(ctx, cmd.Remote)
+	client, err := newClient(cmd.Remote)
 	if err != nil {
 		return err
 	}

--- a/put.go
+++ b/put.go
@@ -13,7 +13,7 @@ type PutCmd struct {
 
 func (cmd *PutCmd) Run(cli *Context) (err error) {
 	ctx := context.Background()
-	client, err := newClient(ctx, cmd.Remote)
+	client, err := newClient(cmd.Remote)
 	if err != nil {
 		return err
 	}

--- a/serve.go
+++ b/serve.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	context "context"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -68,7 +68,7 @@ func (srv *server) Write(stream pb.ByteStream_WriteServer) error {
 	n := int64(0)
 	for {
 		chunk, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			if errCh == nil {
 				return status.Errorf(codes.InvalidArgument, "first WriteRequest must contain ResourceName")
 			}


### PR DESCRIPTION
- Replace deprecated grpc.DialContext with grpc.NewClient (explicitly
  deprecated in v1.64.1: "Deprecated: use NewClient instead")
- Drop unused ctx parameter from newClient since NewClient is lazy
- Replace err == io.EOF with errors.Is(err, io.EOF) in Write handler
  for consistency with the Read handler in the same file
- Remove redundant import alias `context "context"` in serve.go

https://claude.ai/code/session_01DrNx9623mnZ4q95cS6JLq6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernizes Go idioms by replacing deprecated gRPC client setup and cleaning up imports. Simplifies client creation and makes EOF handling consistent; no functional changes expected.

- **Refactors**
  - Replace grpc.DialContext with grpc.NewClient (deprecated in v1.64.1).
  - Remove ctx parameter from newClient; update callers.
  - Use errors.Is(err, io.EOF) in Write handler to match Read.
  - Drop redundant context import alias in serve.go.

<sup>Written for commit 4e4c165b85eddd6846a6487a57cf55c42c935f38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

